### PR TITLE
make Xcode4 static analyzer happy

### DIFF
--- a/objc/CFobLicGenerator.m
+++ b/objc/CFobLicGenerator.m
@@ -40,7 +40,7 @@
 
 - (id)init
 {
-	if ([super init] == nil)
+	if (!(self = [super init]))
 		return nil;
 	
 	[self initOpenSSL];

--- a/objc/CFobLicVerifier.m
+++ b/objc/CFobLicVerifier.m
@@ -75,7 +75,7 @@
 
 - (id)init
 {
-	if ([super init] == nil)
+	if (!(self = [super init]))
 		return nil;
 
 	return self;


### PR DESCRIPTION
just a cosmetic refactoring, Xcode4 complains about init method using self without previously assigning it
