### PR TITLE
Uses Security.framework transforms for base64 handling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -131,6 +131,7 @@ To support registration URLs in your application:
 	<pre>
     &lt;key&gt;NSAppleScriptEnabled&lt;/key&gt;
     &lt;string&gt;YES&lt;/string&gt;
+    
     &lt;key&gt;CFBundleURLTypes&lt;/key&gt;
     &lt;array&gt;
         &lt;dict&gt;

--- a/objc/NSString+PECrypt.m
+++ b/objc/NSString+PECrypt.m
@@ -9,46 +9,28 @@
 //
 
 #import "NSString+PECrypt.h"
-#import <openssl/sha.h>
-#import <openssl/bio.h>
-#import <openssl/evp.h>
+#include <CommonCrypto/CommonDigest.h>
 
 @implementation NSString (PXCrypt)
 
 - (NSData *)sha1 {
-	unsigned char digest[SHA_DIGEST_LENGTH];
-	const char *str = [self UTF8String];
-	SHA1((unsigned char *)str, strlen(str), digest);
-	return [NSData dataWithBytes:digest length:SHA_DIGEST_LENGTH];
+    unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+    NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    CC_SHA1([data bytes], (unsigned int)[data length], digest);
+    return [NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH];
 }
 
-// Based on Dave Dribin's code, http://www.dribin.org/dave/blog/archives/2006/03/12/base64_cocoa/
+// Formely based on Dave Dribin's code, http://www.dribin.org/dave/blog/archives/2006/03/12/base64_cocoa/
+// Updated to use CommonCrypto instead of OpenSSL
 - (NSString *)base64DecodeWithBreaks:(BOOL)lineBreaks {
-    // Create a memory buffer containing Base64-encoded string data.
-	const char *utf8 = [self UTF8String];
-	if (!utf8)
-		return nil;
-	// Create an OpenSSL BIO buffer using UTF8 representation of the string.
-    BIO *mem = BIO_new_mem_buf((void *)utf8, (int)strlen(utf8));
-    // Push a Base64 filter so that reading from the buffer decodes it.
-    BIO *b64 = BIO_new(BIO_f_base64());
-    if (!lineBreaks)
-        BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
-    mem = BIO_push(b64, mem);
-    
-    // Decode into an NSMutableData
-    NSMutableData *data = [NSMutableData data];
-	const int DECODE_BUF_SIZE = 512;
-    char inbuf[DECODE_BUF_SIZE];
-    int inlen;
-    while ((inlen = BIO_read(mem, inbuf, (int)sizeof(inbuf))) > 0)
-        [data appendBytes: inbuf length: inlen];
-	unsigned char zeroByte[1] = {0};
-	[data appendBytes:zeroByte length:1]; // zero-terminate the string
-    // Clean up.
-    BIO_free_all(mem);
-	// Use decoded data bytes to construct a new string.
-	NSString *decoded = [NSString stringWithUTF8String:[data bytes]];
+    SecTransformRef transform = SecDecodeTransformCreate(kSecBase64Encoding, NULL);
+    NSData *output = nil;
+    if (SecTransformSetAttribute(transform, kSecTransformInputAttributeName, [self dataUsingEncoding:NSASCIIStringEncoding], NULL)) {
+        output = (NSData *)SecTransformExecute(transform, NULL);
+    }
+    CFRelease(transform);
+    NSString *decoded = [NSString stringWithUTF8String:[output bytes]];
+    [output release];
     return decoded;
 }
 

--- a/objc/NSString-Base64Extensions.m
+++ b/objc/NSString-Base64Extensions.m
@@ -22,9 +22,7 @@
 // PixelEspresso, http://www.pixelespressoapps.com/
 
 #import "NSString-Base64Extensions.h"
-#import <openssl/bio.h>
-#import <openssl/evp.h>
-
+#import <Security/Security.h>
 
 @implementation NSString (Base64)
 
@@ -33,30 +31,16 @@
     return [self decodeBase64WithNewlines: YES];
 }
 
-- (NSData *) decodeBase64WithNewlines: (BOOL) encodedWithNewlines;
+- (NSData *)decodeBase64WithNewlines:(BOOL)encodedWithNewlines;
 {
-    // Create a memory buffer containing Base64 encoded string data
-	const char *utf8 = [self UTF8String];
-	if (!utf8)
-		return nil;
-    BIO * mem = BIO_new_mem_buf((void *)utf8, strlen(utf8));
-    
-    // Push a Base64 filter so that reading from the buffer decodes it
-    BIO * b64 = BIO_new(BIO_f_base64());
-    if (!encodedWithNewlines)
-        BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
-    mem = BIO_push(b64, mem);
-    
-    // Decode into an NSMutableData
-    NSMutableData * data = [NSMutableData data];
-    char inbuf[512];
-    int inlen;
-    while ((inlen = BIO_read(mem, inbuf, sizeof(inbuf))) > 0)
-        [data appendBytes: inbuf length: inlen];
-    
-    // Clean up and go home
-    BIO_free_all(mem);
-    return data;
+    SecTransformRef transform = SecDecodeTransformCreate(kSecBase64Encoding, NULL);
+    NSData *output = nil;
+    if (SecTransformSetAttribute(transform, kSecTransformInputAttributeName, [self dataUsingEncoding:NSASCIIStringEncoding], NULL)) {
+        output = (NSData *)SecTransformExecute(transform, NULL);
+    }
+    [output autorelease];
+    CFRelease(transform);
+    return output;
 }
 
 @end


### PR DESCRIPTION
Updates the NSString class categories to use Security.framework transforms instead of OpenSSL BIO for base64 handling, merges in changes from master. Hope it's handy for others!
