### PR TITLE
Add a header-only variant of CFobLicVerifier.

### DIFF
--- a/objc/CFobLicVerifier-HeaderOnly.h
+++ b/objc/CFobLicVerifier-HeaderOnly.h
@@ -24,7 +24,7 @@ enum _CFobErrorCode {
 static inline void CFobAssignErrorWithDescriptionAndCode(NSError **err, NSString *description, NSInteger code)
 {
 	if (err != NULL)
-		*err = [NSError errorWithDomain:[[NSBundle bundleForClass:NSClassFromString(@"CFobLicVerifier")] bundleIdentifier] code:code userInfo:[NSDictionary dictionaryWithObject:NSLocalizedStringFromTableInBundle(description, nil, [NSBundle bundleForClass:NSClassFromString(@"CFobLicVerifier")], nil) forKey:NSLocalizedDescriptionKey]];
+		*err = [NSError errorWithDomain:@"cocoafob" code:code userInfo:[NSDictionary dictionaryWithObject:description forKey:NSLocalizedDescriptionKey]];
 }
 
 static inline NSString *CFobCompletePublicKeyPEM(NSString *partialPEM) {

--- a/objc/CFobLicVerifier-HeaderOnly.h
+++ b/objc/CFobLicVerifier-HeaderOnly.h
@@ -58,7 +58,7 @@ static inline SecKeyRef CFobSetPublicKey(NSString *pubKey, NSError **err) {
 	// Validate the argument.
 	if (pubKey == nil || [pubKey length] < 1) {
 		CFobAssignErrorWithDescriptionAndCode(err, @"Invalid key.", CFobErrorCodeInvalidKey);
-		return NO;
+		return NULL;
 	}
 
 	SecItemImportExportKeyParameters params = {};
@@ -76,7 +76,7 @@ static inline SecKeyRef CFobSetPublicKey(NSString *pubKey, NSError **err) {
 		if (importArray) {
 			CFRelease(importArray);
 		}
-		return NO;
+		return NULL;
 	}
 
 	SecKeyRef keyRef = (SecKeyRef)CFRetain(CFArrayGetValueAtIndex(importArray, 0));

--- a/objc/CFobLicVerifier-HeaderOnly.h
+++ b/objc/CFobLicVerifier-HeaderOnly.h
@@ -1,0 +1,139 @@
+//
+//  CFobLicVerifier-HeaderOnly.h
+//  cocoafob
+//
+//  Created by Daniel Alm on 24.11.15.
+//  Copyright 2009-2015 PixelEspresso, Daniel Alm. All rights reserved.
+//  Licensed under BSD license.
+//
+
+#ifndef CFobLicVerifier_HeaderOnly_h
+#define CFobLicVerifier_HeaderOnly_h
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+enum _CFobErrorCode {
+	CFobErrorCodeInvalidKey = -1,
+	CFobErrorCodeCouldNotDecode = -2,
+	CFobErrorCodeSigningFailed = -3,
+	CFobErrorCodeCouldNotEncode = -4,
+	CFobErrorCodeNoName = -5,
+};
+
+static inline void CFobAssignErrorWithDescriptionAndCode(NSError **err, NSString *description, NSInteger code)
+{
+	if (err != NULL)
+		*err = [NSError errorWithDomain:[[NSBundle bundleForClass:NSClassFromString(@"CFobLicVerifier")] bundleIdentifier] code:code userInfo:[NSDictionary dictionaryWithObject:NSLocalizedStringFromTableInBundle(description, nil, [NSBundle bundleForClass:NSClassFromString(@"CFobLicVerifier")], nil) forKey:NSLocalizedDescriptionKey]];
+}
+
+static inline NSString *CFobCompletePublicKeyPEM(NSString *partialPEM) {
+	NSString *dashes = @"-----";
+	NSString *begin = @"BEGIN";
+	NSString *end = @"END";
+	NSString *key = @"KEY";
+	NSString *public = @"DSA PUBLIC";
+	NSMutableString *pem = [NSMutableString string];
+	[pem appendString:dashes];
+	[pem appendString:begin];
+	[pem appendString:@" "];
+	[pem appendString:public];
+	[pem appendString:@" "];
+	[pem appendString:key];
+	[pem appendString:dashes];
+	[pem appendString:@"\n"];
+	[pem appendString:partialPEM];
+	[pem appendString:dashes];
+	[pem appendString:end];
+	[pem appendString:@" "];
+	[pem appendString:public];
+	[pem appendString:@" "];
+	[pem appendString:key];
+	[pem appendString:dashes];
+	[pem appendString:@"\n"];
+	return [NSString stringWithString:pem];
+}
+
+static inline SecKeyRef CFobSetPublicKey(NSString *pubKey, NSError **err) {
+	// Validate the argument.
+	if (pubKey == nil || [pubKey length] < 1) {
+		CFobAssignErrorWithDescriptionAndCode(err, @"Invalid key.", CFobErrorCodeInvalidKey);
+		return NO;
+	}
+
+	SecItemImportExportKeyParameters params = {};
+	SecExternalItemType keyType = kSecItemTypePublicKey;
+	SecExternalFormat keyFormat = kSecFormatPEMSequence;
+	CFArrayRef importArray = NULL;
+
+	NSData *pubKeyData = [pubKey dataUsingEncoding:NSUTF8StringEncoding];
+	CFDataRef pubKeyDataRef = (__bridge CFDataRef)pubKeyData;
+
+	OSStatus importError = SecItemImport(pubKeyDataRef, NULL, &keyFormat, &keyType, 0, &params, NULL, &importArray);
+
+	if (importError) {
+		CFobAssignErrorWithDescriptionAndCode(err, @"Unable to decode key.", CFobErrorCodeCouldNotDecode);
+		if (importArray) {
+			CFRelease(importArray);
+		}
+		return NO;
+	}
+
+	SecKeyRef keyRef = (SecKeyRef)CFRetain(CFArrayGetValueAtIndex(importArray, 0));
+	CFRelease(importArray);
+	return keyRef;
+}
+
+static inline BOOL CFobVerifyRegCode(SecKeyRef keyRef, NSString *regCode, NSString *name, NSError **err) {
+	if (name == nil || [name length] < 1) {
+		CFobAssignErrorWithDescriptionAndCode(err, @"No name for the registration code.", CFobErrorCodeNoName);
+		return NO;
+	}
+
+	// Replace 9s with Is and 8s with Os
+	NSString *regKeyTemp = [regCode stringByReplacingOccurrencesOfString:@"9" withString:@"I"];
+	NSString *regKeyBase32 = [regKeyTemp stringByReplacingOccurrencesOfString:@"8" withString:@"O"];
+	// Remove dashes from the registration key if they are there (dashes are optional).
+	NSString *keyNoDashes = [regKeyBase32 stringByReplacingOccurrencesOfString:@"-" withString:@""];
+	NSData *keyData = [keyNoDashes dataUsingEncoding:NSUTF8StringEncoding];
+	NSData *nameData = [name dataUsingEncoding:NSUTF8StringEncoding];
+	CFDataRef keyDataRef = (__bridge CFDataRef)keyData;
+	CFDataRef nameDataRef = (__bridge CFDataRef)nameData;
+
+	// Note: A transform group is not used here because there appears to be a bug connecting the output of a decode transform to kSecSignatureAttributeName. Execution of the group randomly fails.
+
+	BOOL result = NO;
+	SecTransformRef decoder = SecDecodeTransformCreate(kSecBase32Encoding, NULL);
+	if (decoder) {
+		SecTransformSetAttribute(decoder, kSecTransformInputAttributeName, keyDataRef, NULL);
+		CFDataRef signature = SecTransformExecute(decoder, NULL);
+		if (signature) {
+			SecTransformRef verifier = SecVerifyTransformCreate(keyRef, signature, NULL);
+			if (verifier) {
+				SecTransformSetAttribute(verifier, kSecTransformInputAttributeName, nameDataRef, NULL);
+				SecTransformSetAttribute(verifier, kSecDigestTypeAttribute, kSecDigestSHA1, NULL);
+				CFErrorRef error;
+				CFBooleanRef transformResult = SecTransformExecute(verifier, &error);
+				if (transformResult) {
+					result = (transformResult == kCFBooleanTrue);
+					CFRelease(transformResult);
+				}
+				CFRelease(verifier);
+			}
+			CFRelease(signature);
+		}
+		CFRelease(decoder);
+	}
+	return result;
+}
+
+static inline BOOL CFobIsRegistered(NSString *partialPEM, NSString *regCode, NSString *name, NSError **err) {
+	NSString *publicKey = CFobCompletePublicKeyPEM(partialPEM);
+	SecKeyRef keyRef = CFobSetPublicKey(publicKey, err);
+	if (!keyRef) return NO;
+	BOOL result = CFobVerifyRegCode(keyRef, regCode, name, err);
+	CFRelease(keyRef);
+	return result;
+}
+
+#endif /* CFobLicVerifier_HeaderOnly_h */

--- a/objc/CocoaFobTests/CFobLicVerifier-HeaderOnlyTest.m
+++ b/objc/CocoaFobTests/CFobLicVerifier-HeaderOnlyTest.m
@@ -1,0 +1,59 @@
+//
+//  CFobLicVerifier-HeaderOnlyTest.m
+//  cocoafob
+//
+//  Created by Daniel Alm on 24.11.15.
+//
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CFobLicVerifier-HeaderOnly.h"
+
+@interface CFobLicVerifier_HeaderOnlyTest : XCTestCase
+@property (nonatomic, copy) NSString *partialPEM;
+@end
+
+@implementation CFobLicVerifier_HeaderOnlyTest
+
+- (void)setUp
+{
+	[super setUp];
+
+	// Modelled after AquaticPrime's method of splitting public key to obfuscate it.
+	// It is probably better if you invent your own splitting pattern. Go wild.
+	NSMutableString *pubKeyBase64 = [NSMutableString string];
+	[pubKeyBase64 appendString:@"MIHxMIGoBgcqhkj"];
+	[pubKeyBase64 appendString:@"OOAQBMIGcAkEA8wm04e0QcQRoAVJW"];
+	[pubKeyBase64 appendString:@"WnUw/4rQEKbLKjujJu6o\n"];
+	[pubKeyBase64 appendString:@"yE"];
+	[pubKeyBase64 appendString:@"v7Y2oT3itY5pbObgYCHEu9FBizqq7apsWYSF3YX"];
+	[pubKeyBase64 appendString:@"iRjKlg10wIVALfs9eVL10Ph\n"];
+	[pubKeyBase64 appendString:@"oV6zczFpi3C7FzWNAkBaPhALEKlgIltHsumHdTSBqaVoR1/bmlgw"];
+	[pubKeyBase64 appendString:@"/BCC13IAsW40\n"];
+	[pubKeyBase64 appendString:@"nkFNsK1OVwjo2ocn"];
+	[pubKeyBase64 appendString:@"3M"];
+	[pubKeyBase64 appendString:@"wW"];
+	[pubKeyBase64 appendString:@"4Rdq6uLm3DlENRZ5bYrTA"];
+	[pubKeyBase64 appendString:@"0QAAkEA4reDYZKAl1vx+8EI\n"];
+	[pubKeyBase64 appendString:@"MP/+"];
+	[pubKeyBase64 appendString:@"2Z7ekydHfX0sTMDgkxhtRm6qtcywg01X847Y9ySgNepqleD+Ka2Wbucj1pOr\n"];
+	[pubKeyBase64 appendString:@"y8MoDQ==\n"];
+
+	self.partialPEM = pubKeyBase64;
+}
+
+- (void)testVerifyInHeader {
+	[self measureBlock:^{
+		NSError *error = nil;
+		NSString *regCode = @"GAWQE-F9AQP-XJCCL-PAFAX-NU5XX-EUG6W-KLT3H-VTEB9-A9KHJ-8DZ5R-DL74G-TU4BN-7ATPY-3N4XB-V4V27-Q";
+		NSString *name = @"Joe Bloggs";
+		XCTAssertTrue(CFobIsRegistered(self.partialPEM, regCode, name, &error));
+		XCTAssertNil(error);
+
+		XCTAssertFalse(CFobIsRegistered(self.partialPEM, regCode, @"Joe Bloggt", &error));
+		XCTAssertFalse(CFobIsRegistered(self.partialPEM, @"GAWQE-F9AQP-XJCCL-PAFAX-NU5XX-EUG6W-KLT3H-VTEB9-A9KHJ-8DZ5R-DL74G-TU4BN-7ATPY-3N4XB-V4V27-P", name, &error));
+	}];
+}
+
+@end

--- a/objc/NSString+PECrypt.m
+++ b/objc/NSString+PECrypt.m
@@ -25,12 +25,20 @@
 - (NSString *)base64DecodeWithBreaks:(BOOL)lineBreaks {
     SecTransformRef transform = SecDecodeTransformCreate(kSecBase64Encoding, NULL);
     NSData *output = nil;
+#if !__has_feature(objc_arc)
     if (SecTransformSetAttribute(transform, kSecTransformInputAttributeName, [self dataUsingEncoding:NSASCIIStringEncoding], NULL)) {
         output = (NSData *)SecTransformExecute(transform, NULL);
     }
+	CFRelease(transform);
+	NSString *decoded = [NSString stringWithUTF8String:[output bytes]];
+	[output release];
+#else
+    if (SecTransformSetAttribute(transform, kSecTransformInputAttributeName, (__bridge CFTypeRef _Nonnull)([self dataUsingEncoding:NSASCIIStringEncoding]), NULL)) {
+        output = (NSData *)CFBridgingRelease(SecTransformExecute(transform, NULL));
+    }
     CFRelease(transform);
     NSString *decoded = [NSString stringWithUTF8String:[output bytes]];
-    [output release];
+#endif
     return decoded;
 }
 

--- a/objc/cocoafob.xcodeproj/project.pbxproj
+++ b/objc/cocoafob.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		303526981223DC9600AACD22 /* CFobError.m in Sources */ = {isa = PBXBuildFile; fileRef = 303526971223DC9600AACD22 /* CFobError.m */; };
 		303526F41223E4C900AACD22 /* CocoaFob.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 303524081223BB9600AACD22 /* CocoaFob.framework */; };
 		303526FC1223E56000AACD22 /* cocoafob.m in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* cocoafob.m */; };
+		65ABCE831C04F6A60063B6CB /* CFobLicVerifier-HeaderOnlyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 65ABCE821C04F6A60063B6CB /* CFobLicVerifier-HeaderOnlyTest.m */; };
 		C70720321B48C8D80083F859 /* CocoaFobTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C70720311B48C8D80083F859 /* CocoaFobTests.m */; };
 		C70720341B48C8D80083F859 /* CocoaFobARC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7F7EF2C1577F3D90067C3A3 /* CocoaFobARC.framework */; };
 		C74F939215F28769004C00EA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C74F939115F28769004C00EA /* Security.framework */; };
@@ -54,6 +55,8 @@
 		303526831223D4DA00AACD22 /* CFobError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFobError.h; sourceTree = "<group>"; };
 		303526971223DC9600AACD22 /* CFobError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CFobError.m; sourceTree = "<group>"; };
 		303526E91223E45100AACD22 /* cocoafob */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cocoafob; sourceTree = BUILT_PRODUCTS_DIR; };
+		65ABCE811C04F6510063B6CB /* CFobLicVerifier-HeaderOnly.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CFobLicVerifier-HeaderOnly.h"; sourceTree = "<group>"; };
+		65ABCE821C04F6A60063B6CB /* CFobLicVerifier-HeaderOnlyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CFobLicVerifier-HeaderOnlyTest.m"; sourceTree = "<group>"; };
 		C6859EA3029092ED04C91782 /* cocoafob.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = cocoafob.1; sourceTree = "<group>"; };
 		C707202F1B48C8D80083F859 /* CocoaFobTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CocoaFobTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70720311B48C8D80083F859 /* CocoaFobTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CocoaFobTests.m; sourceTree = "<group>"; };
@@ -129,6 +132,7 @@
 				C7E378490F59DB15002061CD /* CFobLicVerifier.h */,
 				C7E3784A0F59DB15002061CD /* CFobLicVerifier.m */,
 				303526831223D4DA00AACD22 /* CFobError.h */,
+				65ABCE811C04F6510063B6CB /* CFobLicVerifier-HeaderOnly.h */,
 				303526971223DC9600AACD22 /* CFobError.m */,
 			);
 			name = Source;
@@ -174,6 +178,7 @@
 			isa = PBXGroup;
 			children = (
 				C70720311B48C8D80083F859 /* CocoaFobTests.m */,
+				65ABCE821C04F6A60063B6CB /* CFobLicVerifier-HeaderOnlyTest.m */,
 				C70720331B48C8D80083F859 /* Info.plist */,
 			);
 			path = CocoaFobTests;
@@ -366,6 +371,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C70720321B48C8D80083F859 /* CocoaFobTests.m in Sources */,
+				65ABCE831C04F6A60063B6CB /* CFobLicVerifier-HeaderOnlyTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
In theory this is minimally more secure than using a swizzable Objective-C class. Note that the header-only variant requires ARC.

Also adds ARC support to NSString+PECrypt.
