### PR TITLE
Ignore .xcscmblueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .idea
 xcuserdata
 *.xccheckout
+*.xcscmblueprint


### PR DESCRIPTION
This is Xcode’s source control data: the sequel to .xccheckout.

Ignoring this fixes the repository being marked as dirty after opening either the Swift of Objective-C Xcode project.