### PR TITLE
Extract license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,8 @@
-Written by Gleb Dolgich and contributors
-
-Twitter: @glebd
-
-Web: <https://pixelespressoapps.com>
-
 CocoaFob is distributed under the BSD License
 <http://www.opensource.org/licenses/bsd-license.php>
 
-Copyright &copy; 2009-2016, PixelEspresso. All rights reserved.
+Copyright (c) 2009-2016, PixelEspresso <https://pixelespressoapps.com>. All rights reserved.
+Written by Gleb Dolgich (@glebd) and contributors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Written by Gleb Dolgich and contributors
+
+Twitter: @glebd
+
+Web: <https://pixelespressoapps.com>
+
+CocoaFob is distributed under the BSD License
+<http://www.opensource.org/licenses/bsd-license.php>
+
+Copyright &copy; 2009-2016, PixelEspresso. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer. Redistributions in binary form
+must reproduce the above copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other materials provided with
+the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.markdown
+++ b/README.markdown
@@ -193,36 +193,8 @@ See [2] for more information.
 
 # Licence
 
-Written by Gleb Dolgich and contributors
-
-Twitter: @glebd
-
-Web: <https://pixelespressoapps.com>
-
 CocoaFob is distributed under the BSD License
-<http://www.opensource.org/licenses/bsd-license.php>
-
-Copyright &copy; 2009-2016, PixelEspresso. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer. Redistributions in binary form
-must reproduce the above copyright notice, this list of conditions and the
-following disclaimer in the documentation and/or other materials provided with
-the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+<http://www.opensource.org/licenses/bsd-license.php>. See the [LICENSE](LICENSE) file.
 
 # Credits
 


### PR DESCRIPTION
Again I forgot that you can find the license in the README (see #28). I think extracting it to a new file is useful because then GitHub displays the license info at the top of the repository for reference. If GitHub can parse the file, that is. We'll see :)

The copyright states 

     Copyright (c) 2009-2016, PixelEspresso <https://pixelespressoapps.com>. All rights reserved.

Should this be extended to 2019 (are you PixelEspresso, @glebd ? :)) Or should we append a line with `Copyright (c) 2016-2019, Gleb Dolgich`?