### PR TITLE
fix typo in Swift 5 heading

### DIFF
--- a/swift4/README.md
+++ b/swift4/README.md
@@ -1,5 +1,7 @@
 # CocoaFob Swift 4.0 Port
 
+For a version targeting Swift 5, see https://github.com/glebd/cocoafob/tree/master/swift5
+
 ## Instructions
 
 Add the necessary files directly to your project. For your app they are:

--- a/swift5/README.md
+++ b/swift5/README.md
@@ -1,4 +1,6 @@
-# CocoaFob Swift 4.0 Port
+# CocoaFob Swift 5.0 Port
+
+For a Swift 4-based version, see https://github.com/glebd/cocoafob/tree/master/swift4
 
 ## Instructions
 


### PR DESCRIPTION
Forgot to increment the README's version number, apparently. While I was at it, I also included links between the v4 and  v5