### PR TITLE
Release 2.2.1

### DIFF
--- a/CocoaFob.podspec
+++ b/CocoaFob.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CocoaFob'
-  s.version          = '2.2.0'
+  s.version          = '2.2.1'
   s.swift_versions   = ["5.6", "5.5", "5.4", '5.3', '5.2', '5.1', '5.0']
   s.summary          = 'macOS app registration code verification & generation.'
   s.description      = <<-DESC

--- a/CocoaFob.podspec
+++ b/CocoaFob.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'CocoaFob'
   s.version          = '2.2.0'
-  s.swift_versions   = ['5.3', '5.2', '5.1', '5.0']
+  s.swift_versions   = ["5.6", "5.5", "5.4", '5.3', '5.2', '5.1', '5.0']
   s.summary          = 'macOS app registration code verification & generation.'
   s.description      = <<-DESC
 CocoaFob is a set of helper code snippets for registration code generation and
@@ -13,7 +13,7 @@ FastSpring <http://fastspring.com>.
   s.homepage         = 'https://github.com/glebd/cocoafob'
   s.license          = 'BSD'
   s.author           = { 'Gleb Dolgich' => '@glebd' }
-  s.source           = { :git => 'https://github.com/glebd/cocoafob.git', :branch => 'master' }
+  s.source           = { :git => 'https://github.com/glebd/cocoafob.git', :tag => s.version }
 
   s.module_name = 'CocoaFob'
   s.platform = :osx


### PR DESCRIPTION
The version string is just used by CocoaPods. This fixes a `pod lib lint` warning. But we'll need a tagged release for stable SwiftPM support.

I'll tag the merge commit afterwards, then publish to CocoaPods *and* SwiftPM