### PR TITLE
Add tests to verify leading/trailing garbage doesn't pass during license verification

### DIFF
--- a/swift5/CocoaFobTests/CocoaFobTests.swift
+++ b/swift5/CocoaFobTests/CocoaFobTests.swift
@@ -191,5 +191,23 @@ class CocoaFobTests: XCTestCase {
       XCTAssert(false, "\(error)")
     }
   }
+
+  func testVerifyAdditionalTrailingCharactersFail() {
+    let verifier = LicenseVerifier(publicKeyPEM: publicKeyPEM)
+    XCTAssertNotNil(verifier?.pubKey)
+    let name = "Joe Bloggs"
+    let regKey = "GAWQE-F9AQP-XJCCL-PAFAX-NU5XX-EUG6W-KLT3H-VTEB9-A9KHJ-8DZ5R-DL74G-TU4BN-7ATPY-3N4XB-V4V27-Qasdf"
+    let result = verifier?.verify(regKey, forName: name) ?? false
+    XCTAssertFalse(result)
+  }
+
+  func testVerifyAdditionalLeadingCharactersFail() {
+    let verifier = LicenseVerifier(publicKeyPEM: publicKeyPEM)
+    XCTAssertNotNil(verifier?.pubKey)
+    let name = "Joe Bloggs"
+    let regKey = "qwertGAWQE-F9AQP-XJCCL-PAFAX-NU5XX-EUG6W-KLT3H-VTEB9-A9KHJ-8DZ5R-DL74G-TU4BN-7ATPY-3N4XB-V4V27-Q"
+    let result = verifier?.verify(regKey, forName: name) ?? false
+    XCTAssertFalse(result)
+  }
   
 }


### PR DESCRIPTION
@trailfog mentioned a test like this in #50 but we forgot to include that in #55

I was investigating this because license codes of some of my users don't work anymore. And I wonder why that is, to be honest.