### PR TITLE
Prepare v2.3.0 release

### DIFF
--- a/CocoaFob.podspec
+++ b/CocoaFob.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CocoaFob'
-  s.version          = '2.2.1'
+  s.version          = '2.3.0'
   s.swift_versions   = ["5.6", "5.5", "5.4", '5.3', '5.2', '5.1', '5.0']
   s.summary          = 'macOS app registration code verification & generation.'
   s.description      = <<-DESC


### PR DESCRIPTION
This merely tags a release of recent PR's.

I'm proposing changes to the Swift toolchain for Xcode 14 in another PR. IMHO we should first:

1. FF merge this, then 
2. tag the commit for SwiftPM, then
3. push to `pod trunk`

That way, the previous toolchain get the latest content updates.

Then we can merge #62 and bump the minor version yet again to pin the latest Swift toolchains.