### PR TITLE
Use OPENSSL_ALGO_SHA1 instead of deprecated DSS1

### DIFF
--- a/php/License/license_generator.php
+++ b/php/License/license_generator.php
@@ -70,7 +70,7 @@ class License_Generator
 		// decode Key
 		$decodedHash = base32_decode($undashed);
 
-		$ok = openssl_verify($stringData, $decodedHash, $this->public_key, OPENSSL_ALGO_DSS1);
+		$ok = openssl_verify($stringData, $decodedHash, $this->public_key, OPENSSL_ALGO_SHA1);
 		if ($ok == 1) {
 		    return TRUE;
 		} elseif ($ok == 0) {


### PR DESCRIPTION
For DSS1, you get `openssl_sign(): Unknown signature algorithm` (for the constant's old value `5`) and also undefined constant errors with PHP 7+ and openssl v1.1+

Not sure if this should instead be made conditional, but who's using PHP 5 and OpenSSL 0.x nowadays anyway, right? 