### PR TITLE
Chore: Use SHA1 in all PHP scripts, replace deprecated constructor

### DIFF
--- a/php/License/license_generator.php
+++ b/php/License/license_generator.php
@@ -7,7 +7,7 @@ class License_Generator
 
 	#-#############################################
 	# desc: constructor
-	function License_Generator(){
+	function __construct() {
 
 
 		## NOTE ###############################################

--- a/php/License/license_generator.php
+++ b/php/License/license_generator.php
@@ -32,7 +32,7 @@ class License_Generator
 
 		#################################################
 		$binary_signature ="";
-		openssl_sign($stringData, $binary_signature, $this->private_key, OPENSSL_ALGO_DSS1);
+		openssl_sign($stringData, $binary_signature, $this->private_key, OPENSSL_ALGO_SHA1);
 		// base 32 encode the signature
 		$encoded = base32_encode($binary_signature);
 		// replace O with 8 and I with 9

--- a/php/licensekey.php
+++ b/php/licensekey.php
@@ -50,7 +50,7 @@ class License_Generator
 		$stringData = $product_code.",".$name.",".$email;
 	echo "Data: ".$stringData."<br>";
 		$binary_signature ="";
-		openssl_sign($stringData, $binary_signature, $this->private_key, OPENSSL_ALGO_DSS1);
+		openssl_sign($stringData, $binary_signature, $this->private_key, OPENSSL_ALGO_SHA1);
 	echo "Binary Sig: ".$binary_signature."<br>";
 		
 		// base 32 encode the stuff
@@ -104,7 +104,7 @@ class License_Generator
 	echo "Binary Sig: ".$decodedHash. "<br>";				
 		//digest the original Data
 		$stringData = $product_code.",".$name.",".$email;
-		$ok = openssl_verify($stringData, $decodedHash, $this->public_key, OPENSSL_ALGO_DSS1);
+		$ok = openssl_verify($stringData, $decodedHash, $this->public_key, OPENSSL_ALGO_SHA1);
 		if ($ok == 1) {
 		    echo "<strong>GOOD</strong>";
 		} elseif ($ok == 0) {


### PR DESCRIPTION
Just a bit of cleanup to use SHA1 consistently